### PR TITLE
Remove 'courses' tab and underline

### DIFF
--- a/templates/main.mustache
+++ b/templates/main.mustache
@@ -24,13 +24,6 @@
 }}
 
 <div id="block-myoverview-{{uniqid}}" class="block-myoverview" data-region="myoverview">
-    <ul id="block-myoverview-view-choices-{{uniqid}}" class="nav nav-tabs" role="tablist">
-        <li class="nav-item">
-            <a class="nav-link {{#viewingcourses}}active{{/viewingcourses}}" href="#myoverview_courses_view" role="tab" data-toggle="tab" data-tabname="courses">
-                {{#str}} courses {{/str}}
-            </a>
-        </li>
-    </ul>
     <div class="tab-content content-centred">
         <div role="tabpanel" class="tab-pane fade {{#viewingtimeline}}in active{{/viewingtimeline}}" id="myoverview_timeline_view">
             {{> block_myoverview/timeline-view }}


### PR DESCRIPTION
Save space in the block since we’ve removed courses/timeline
functionality